### PR TITLE
Documente la fuite de Lyra et la nouvelle piste Kaelith

### DIFF
--- a/data/sessions/2025-09-26-prologue.json
+++ b/data/sessions/2025-09-26-prologue.json
@@ -7,7 +7,8 @@
   "objectifs": [
     {
       "description": "Sécuriser un sauf-conduit diplomatique vers les clans de Thorgar.",
-      "etat": "en_cours"
+      "etat": "en_cours",
+      "notes": "Sauf-conduit obtenu sans escorte grâce à l'intervention de la chancelière Maelis."
     },
     {
       "description": "Identifier l'origine des résidus d'ombre découverts dans les réservoirs de brume de Valoria.",
@@ -30,11 +31,17 @@
           "difficulte": 12,
           "modificateurs": ["Avantage si Lyra invoque son lien avec la chancelière Maelis"],
           "reussite": "Obtention d'un sauf-conduit et d'un messager officiel.",
-          "echec": "Le conseil impose un chevalier escortant chargé de surveiller Lyra."
+          "echec": "Le conseil impose un chevalier escortant chargé de surveiller Lyra.",
+          "resultat": "Jet réussi (18) : Maelis annule l'escorte des Lames de Cobalte et valide le sauf-conduit."
         }
       ],
       "complications": ["Interruption par la maison Lames de Cobalte qui dévoile un témoin compromettant."],
-      "informations": ["Rumeurs de rituels interdits menés dans les catacombes du quartier des artificiers."]
+      "informations": ["Rumeurs de rituels interdits menés dans les catacombes du quartier des artificiers."],
+      "etat": "résolu",
+      "resultats": [
+        "Lyra exploite son lien avec Maelis Veyr pour rejeter publiquement l'escorte imposée.",
+        "Profitant de la confusion, elle déclenche un voile de brume et disparaît avant que les Lames de Cobalte puissent réagir."
+      ]
     },
     {
       "ordre": 2,
@@ -57,7 +64,11 @@
         }
       ],
       "complications": ["Manifestation mineure de l'Ombre : tentacules de brume qui affaiblissent les tests de Magie."],
-      "informations": ["Serelune craint une alliance Valoria/Thorgar et prépare une contre-propagande."]
+      "informations": ["Serelune craint une alliance Valoria/Thorgar et prépare une contre-propagande."],
+      "pistes": [
+        "Lyra a identifié Kaelith parmi les observateurs et soupçonne une coalition anti-trêve mêlant Serelune et une maison valorienne rivale.",
+        "Une silhouette encapuchonnée a détourné l'attention des gardes au même instant que la fuite de Lyra, suggérant une complicité interne."
+      ]
     },
     {
       "ordre": 3,
@@ -86,7 +97,7 @@
   "decisions_attendues": [
     "Lyra priorise-t-elle la diplomatie ou la traque de l'espion après le conseil ?",
     "Utilisera-t-elle les messages chiffrés pour négocier avec Serelune ou les remettre au Conseil ?",
-    "Acceptera-t-elle la présence d'un chevalier escortant imposé par les nobles ?"
+    "Quelle piste suivra-t-elle pour confirmer l'existence du complot visant la trêve ?"
   ],
   "cliffhanger_prevu": "Au terme de la session, une fissure de l'Ombre s'ouvrira sous la citerne, révélant une voix qui connaît le passé de Lyra.",
   "preparation_prochaine_session": [

--- a/data/world_state.json
+++ b/data/world_state.json
@@ -11,6 +11,18 @@
         "Soupçons renforcés envers les espions de Serelune dans la capitale.",
         "Première manifestation notable de l'Ombre à Valoria depuis six mois."
       ]
+    },
+    {
+      "date": "2025-09-26",
+      "arc": "Arc I – Braises d'Empire",
+      "saison": "Automne 1235 FA",
+      "session": "2025-09-26-A",
+      "evenement": "Lyra refuse l'escorte des Lames de Cobalte en invoquant son lien avec Maelis et se lance à la poursuite de l'espion Kaelith.",
+      "impact": [
+        "Crédibilité politique renforcée pour la chancelière Maelis face au Conseil.",
+        "Les Lames de Cobalte soupçonnent une fuite d'informations interne et resserrent leurs surveillances.",
+        "Indice d'un complot anti-trêve reliant Serelune à une maison noble valorienne."
+      ]
     }
   ],
   "factions": {
@@ -33,7 +45,8 @@
       ],
       "menaces": [
         "Infiltration des Veilleurs du Voile",
-        "Usure des Lames de Cobalte"
+        "Usure des Lames de Cobalte",
+        "Complot anti-trêve au sein du Conseil"
       ]
     },
     "Thorgar": {
@@ -77,7 +90,8 @@
       ],
       "menaces": [
         "Instabilité des marées magiques",
-        "Division entre le clergé et les corsaires"
+        "Division entre le clergé et les corsaires",
+        "Couverture de Kaelith compromise à Valoria"
       ]
     },
     "Khar'Seth": {
@@ -140,7 +154,7 @@
       "nom": "Trêve fragile",
       "niveau": 1,
       "tendance": "dégringolade",
-      "description": "L'accord entre Valoria et Thorgar tient à la réussite de la mission diplomatique de Lyra."
+      "description": "L'accord entre Valoria et Thorgar dépend désormais de la capacité de Lyra à déjouer le complot anti-trêve tout en sécurisant le sauf-conduit."
     }
   ]
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -3,3 +3,4 @@
 ## Journal des contributions
 - 2025-09-26 | Initialisation de la structure du dépôt selon la méthode de vibe coding de Mozi : création des dossiers de données, des journaux, de l'étoile polaire et du guide de méthode.
 - 2025-09-26 | Lancement de la campagne : création de la fiche de Lyra Valen, préparation de la session d'introduction et mise à jour de l'état du monde.
+- 2025-09-27 | Résolution de la scène du Conseil : Lyra refuse l'escorte, identification de la piste Kaelith et mise à jour des données de session et d'état du monde.

--- a/logs/dice_rolls.log
+++ b/logs/dice_rolls.log
@@ -1,1 +1,2 @@
 # Journal des jets de dés — initialisé le 2025-09-26T21:10:12Z
+2025-09-27T08:30:00Z | Influence | Avantage (lien avec Maelis Veyr) | 18


### PR DESCRIPTION
## Résumé
- consigne la réussite de Lyra au Conseil et sa disparition sans escorte dans le journal de session
- enrichit l'état du monde avec les conséquences politiques et la piste de complot anti-trêve
- trace le jet d'Influence associé et met à jour le backlog de contribution

## Tests
- `python - <<'PY'` (validation de la structure JSON mise à jour)


------
https://chatgpt.com/codex/tasks/task_e_68d70aaf559483309b6ce5117563bca0