### PR TITLE
Documenter les nouvelles directives de réponse et le journal narratif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# dnd
+# Chroniques des Royaumes Brisés
+
+Ce dépôt suit la méthode de vibe coding de Mozi pour piloter une campagne de jeu de rôle persistante.
+
+## Directives récentes
+- L'agent doit lire `player_input.md`, répondre explicitement aux questions posées par le joueur et préparer le prompt suivant en conséquence.
+- Après chaque réponse, l'agent met à jour l'état de la partie ainsi que `player_input.md` pour enchaîner immédiatement sur la scène suivante.
+- Un journal narratif incrémental est consigné dans `docs/histoire_session_en_cours.md` afin que le joueur puisse relire l'évolution de la partie.
+
+Consulter `docs/requirements.md` pour la description complète du projet et `docs/backlog.md` pour l'historique des contributions.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,3 +4,4 @@
 - 2025-09-26 | Initialisation de la structure du dépôt selon la méthode de vibe coding de Mozi : création des dossiers de données, des journaux, de l'étoile polaire et du guide de méthode.
 - 2025-09-26 | Lancement de la campagne : création de la fiche de Lyra Valen, préparation de la session d'introduction et mise à jour de l'état du monde.
 - 2025-09-27 | Résolution de la scène du Conseil : Lyra refuse l'escorte, identification de la piste Kaelith et mise à jour des données de session et d'état du monde.
+- 2025-09-28 | Ajout des directives de réponse aux questions du joueur, création du journal narratif de session et mise à jour du README.

--- a/docs/histoire_session_en_cours.md
+++ b/docs/histoire_session_en_cours.md
@@ -1,0 +1,9 @@
+# Histoire de la session en cours
+
+Ce journal recueille l'évolution détaillée de la partie actuelle. Chaque intervention de l'agent doit ajouter une nouvelle section avec :
+- la date et l'heure (UTC) de la mise à jour ;
+- un résumé narratif des événements survenus ;
+- les conséquences mécaniques (jets, états, ressources) le cas échéant ;
+- les questions posées par le joueur et les réponses fournies.
+
+_Aucune entrée n'a encore été consignée pour cette session._

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -64,6 +64,7 @@ Chaque arc est composé de plusieurs **chapitres**. Chaque partie de jeu doit :
 ### 4.1 Structure du dépôt
 ```
 /README.md                  — aperçu du projet
+/docs/histoire_session_en_cours.md — journal narratif incrémental de la session
 /docs/requirements.md       — ce document
 /data/world_state.json      — état global du monde (royaumes, cartes, événements)
 /data/sessions/<date>.json  — journal des sessions
@@ -189,6 +190,7 @@ Chaque arc est composé de plusieurs **chapitres**. Chaque partie de jeu doit :
 3. **Scène 2** : complication croissante.
 4. **Scène 3** : confrontation majeure.
 5. **Épilogue** : conséquences, hooks pour la suite.
+6. **Synthèse** : consigner dans `docs/histoire_session_en_cours.md` les événements narratifs, jets notables et réponses aux questions du joueur.
 
 ### 7.3 Post-session
 - Mettre à jour `world_state.json` (factions, régions, timeline).
@@ -216,6 +218,10 @@ Chaque arc est composé de plusieurs **chapitres**. Chaque partie de jeu doit :
 - Choix proposés pour les suites
 ```
 L'agent lit le fichier, interprète les intentions et réalise les jets de dés nécessaires.
+Chaque réponse de l'agent doit :
+- traiter explicitement toutes les questions posées dans `player_input.md` ;
+- actualiser les données pertinentes (état du monde, journaux, fiches) ;
+- préparer un nouveau `player_input.md` focalisé sur la scène suivante.
 
 ## 9. Contenu additionnel
 - **PNJ majeurs** : liste initiale (généraux, diplomates, espions, mentors) avec arcs personnels.


### PR DESCRIPTION
## Résumé
- mettre à jour le README pour rappeler les directives de réponse aux questions du joueur et le journal narratif
- créer `docs/histoire_session_en_cours.md` pour consigner l'histoire incrémentale de la partie en cours
- compléter les requirements et le backlog avec les nouvelles règles de synthèse et de mise à jour de `player_input.md`

## Tests
- aucun test automatisé requis


------
https://chatgpt.com/codex/tasks/task_e_68d70dfb9b688330acc90e28a225aa0f