### PR TITLE
Poursuite de Kaelith et refonte du terminal d'interaction joueur

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Ce dépôt suit la méthode de vibe coding de Mozi pour piloter une campagne de 
 
 ## Directives récentes
 - L'agent doit lire `player_input.md`, répondre explicitement aux questions posées par le joueur et préparer le prompt suivant en conséquence.
-- Après chaque réponse, l'agent met à jour l'état de la partie ainsi que `player_input.md` pour enchaîner immédiatement sur la scène suivante.
+- Après chaque réponse, l'agent met à jour l'état de la partie ainsi que `player_input.md`.
+- `player_input.md` fait désormais office de terminal d'interaction : il est réécrit à chaque itération pour résumer la scène en cours et demander explicitement au joueur quelles actions entreprendre. La réponse du joueur devient le prompt de l'itération suivante.
 - Un journal narratif incrémental est consigné dans `docs/histoire_session_en_cours.md` afin que le joueur puisse relire l'évolution de la partie.
 
 Consulter `docs/requirements.md` pour la description complète du projet et `docs/backlog.md` pour l'historique des contributions.

--- a/data/sessions/2025-09-26-prologue.json
+++ b/data/sessions/2025-09-26-prologue.json
@@ -53,21 +53,28 @@
           "difficulte": 14,
           "modificateurs": ["Désavantage si Lyra est accompagnée par un garde encombrant"],
           "reussite": "Lyra intercepte Kaelith et obtient un fragment de carte menant à un culte de l'Ombre.",
-          "echec": "Kaelith s'échappe et répand de fausses informations sur Valoria."
+          "echec": "Kaelith s'échappe et répand de fausses informations sur Valoria.",
+          "resultat": "Jet réussi (17) : traque discrète jusqu'à une planque reliée à la maison Dyrion."
         },
         {
           "type": "Crochetage",
           "difficulte": 10,
           "modificateurs": ["Avantage avec le sachet de poussière de brume"],
           "reussite": "Accès à une planque contenant des messages chiffrés.",
-          "echec": "Piège arcanique déclenché : Lyra subit 1d6 dégâts de froid."
+          "echec": "Piège arcanique déclenché : Lyra subit 1d6 dégâts de froid.",
+          "resultat": "Jet réussi (16 avec avantage) : récupération d'un tube cristallin sans alarme."
         }
       ],
       "complications": ["Manifestation mineure de l'Ombre : tentacules de brume qui affaiblissent les tests de Magie."],
       "informations": ["Serelune craint une alliance Valoria/Thorgar et prépare une contre-propagande."],
+      "progres": [
+        "Identification d'une entremetteuse de la maison Dyrion recevant des rapports de Kaelith.",
+        "Obtention du message chiffré « Glas de la Trêve » et d'une carte partielle des conduits de la citerne."
+      ],
       "pistes": [
         "Lyra a identifié Kaelith parmi les observateurs et soupçonne une coalition anti-trêve mêlant Serelune et une maison valorienne rivale.",
-        "Une silhouette encapuchonnée a détourné l'attention des gardes au même instant que la fuite de Lyra, suggérant une complicité interne."
+        "Une silhouette encapuchonnée a détourné l'attention des gardes au même instant que la fuite de Lyra, suggérant une complicité interne.",
+        "Les catacombes des artificiers contiennent un accès discret aux conduits de la citerne, surveillé par des glyphes sereluniens."
       ]
     },
     {
@@ -95,9 +102,9 @@
     }
   ],
   "decisions_attendues": [
-    "Lyra priorise-t-elle la diplomatie ou la traque de l'espion après le conseil ?",
-    "Utilisera-t-elle les messages chiffrés pour négocier avec Serelune ou les remettre au Conseil ?",
-    "Quelle piste suivra-t-elle pour confirmer l'existence du complot visant la trêve ?"
+    "Comment Lyra exploite-t-elle le message chiffré « Glas de la Trêve » ?",
+    "Prend-elle le risque d'infiltrer immédiatement les conduits de la citerne ou cherche-t-elle d'abord des alliés ?",
+    "Qui confronte-t-elle en priorité entre Kaelith, la maison Dyrion et le Conseil ?"
   ],
   "cliffhanger_prevu": "Au terme de la session, une fissure de l'Ombre s'ouvrira sous la citerne, révélant une voix qui connaît le passé de Lyra.",
   "preparation_prochaine_session": [

--- a/data/world_state.json
+++ b/data/world_state.json
@@ -23,6 +23,18 @@
         "Les Lames de Cobalte soupçonnent une fuite d'informations interne et resserrent leurs surveillances.",
         "Indice d'un complot anti-trêve reliant Serelune à une maison noble valorienne."
       ]
+    },
+    {
+      "date": "2025-09-29",
+      "arc": "Arc I – Braises d'Empire",
+      "saison": "Automne 1235 FA",
+      "session": "2025-09-26-A",
+      "evenement": "Lyra infiltre les catacombes des artificiers, surprend un échange entre Kaelith et un agent de la maison Dyrion et récupère le plan codé de l'opération Glas de la Trêve.",
+      "impact": [
+        "La maison Dyrion est soupçonnée de complicité avec Serelune dans le sabotage de la trêve.",
+        "Lyra obtient une carte partielle des conduits de la citerne, ouvrant une piste d'infiltration.",
+        "La cellule serelunienne active des mesures d'urgence pour sécuriser Kaelith."
+      ]
     }
   ],
   "factions": {
@@ -46,7 +58,8 @@
       "menaces": [
         "Infiltration des Veilleurs du Voile",
         "Usure des Lames de Cobalte",
-        "Complot anti-trêve au sein du Conseil"
+        "Complot anti-trêve au sein du Conseil",
+        "Complicité potentielle de la maison Dyrion"
       ]
     },
     "Thorgar": {
@@ -154,7 +167,7 @@
       "nom": "Trêve fragile",
       "niveau": 1,
       "tendance": "dégringolade",
-      "description": "L'accord entre Valoria et Thorgar dépend désormais de la capacité de Lyra à déjouer le complot anti-trêve tout en sécurisant le sauf-conduit."
+      "description": "L'accord entre Valoria et Thorgar dépend désormais de la capacité de Lyra à déjouer l'opération Glas de la Trêve tout en sécurisant le sauf-conduit."
     }
   ]
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -5,3 +5,4 @@
 - 2025-09-26 | Lancement de la campagne : création de la fiche de Lyra Valen, préparation de la session d'introduction et mise à jour de l'état du monde.
 - 2025-09-27 | Résolution de la scène du Conseil : Lyra refuse l'escorte, identification de la piste Kaelith et mise à jour des données de session et d'état du monde.
 - 2025-09-28 | Ajout des directives de réponse aux questions du joueur, création du journal narratif de session et mise à jour du README.
+- 2025-09-29 | Formalisation du terminal d'interaction joueur, narration de la filature de Kaelith et mise à jour des états du monde et des jets correspondants.

--- a/docs/histoire_session_en_cours.md
+++ b/docs/histoire_session_en_cours.md
@@ -6,4 +6,19 @@ Ce journal recueille l'évolution détaillée de la partie actuelle. Chaque inte
 - les conséquences mécaniques (jets, états, ressources) le cas échéant ;
 - les questions posées par le joueur et les réponses fournies.
 
-_Aucune entrée n'a encore été consignée pour cette session._
+## 2025-09-29T10:15:00Z
+
+### Résumé narratif
+- Lyra invoque discrètement son lien empathique avec la chancelière Maelis pour légitimer sa disparition et se fondre dans la brume.
+- Elle talonne Kaelith jusqu'à une allée dérobée menant aux catacombes des artificiers, où l'espion remet un tube de cristal à une silhouette portant l'emblème discret de la maison Dyrion.
+- Une diversion de brume sombre surgit, suggérant qu'un complice manipulateur de l'Ombre couvre leur échange.
+
+### Conséquences mécaniques
+- Jet de Déplacement (d20, difficulté 14) réussi avec un résultat de 17 : Lyra reste invisible aux sentinelles des Lames de Cobalte.
+- Jet de Crochetage (d20 avec avantage grâce à la poussière de brume, difficulté 10) réussi avec un résultat de 16 : la planque secondaire est ouverte sans déclencher les glyphes d'alerte.
+- Récupération d'un message chiffré décrivant une opération nommée « Glas de la Trêve » et d'une carte incomplète des conduits alimentant la citerne.
+
+### Questions du joueur et réponses
+- Sur la loyauté du chevalier proposé : il s'agit de Dame Ilyana Corven, loyaliste aux Lames de Cobalte mais redevable envers la maison Dyrion ; sa loyauté principale reste tournée vers la protection de Valoria.
+- Risques en cas d'échec de la purification : la pression de brume provoquerait une onde de froid qui toucherait d'abord les quartiers artisans, puis provoquerait des fissures qui exposeraient le palais à l'Ombre.
+- Préparation du jet de Connaissances : les glyphes récupérés offriront un avantage si Lyra prend le temps de les analyser ou de les confier à Maelis pour traduction.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -3,7 +3,7 @@
 ## 1. Vision générale
 - **Type de projet** : campagne de jeu de rôle Donjons & Dragons (D&D 5e inspiré) pilotée via un dépôt Git.
 - **Objectif** : offrir une expérience narrative persistante où chaque session influence durablement l'état du monde.
-- **Mode d'interaction** : le joueur consigne ses décisions et actions dans un fichier Markdown partagé (`player_input.md`). L'agent lit ce fichier à chaque itération pour adapter la narration, effectuer les jets de dés et mettre à jour les données.
+- **Mode d'interaction** : le joueur consigne ses décisions et actions dans un fichier Markdown partagé (`player_input.md`). L'agent lit ce fichier à chaque itération pour adapter la narration, effectuer les jets de dés et mettre à jour les données. À partir du 2025-09-29, `player_input.md` est réécrit par l'agent à chaque tour pour résumer la situation et demander explicitement au joueur quelles suites il choisit. La réponse du joueur sert de prompt direct pour l'itération suivante.
 
 ## 2. Contexte narratif
 ### 2.1 Cadre historique
@@ -218,10 +218,15 @@ Chaque arc est composé de plusieurs **chapitres**. Chaque partie de jeu doit :
 - Choix proposés pour les suites
 ```
 L'agent lit le fichier, interprète les intentions et réalise les jets de dés nécessaires.
+À partir du nouveau mode d'itération :
+- `player_input.md` sert de terminal de dialogue ; chaque réponse de l'agent inclut une version mise à jour du fichier qui formule clairement les choix offerts au joueur.
+- Le joueur répond en éditant le fichier (ou en envoyant un message reprenant les champs demandés) et cette réponse devient le prompt de l'agent pour la scène suivante.
+- Les sections peuvent être adaptées pour refléter la scène en cours (ex. remplacer "Actions proposées" par "Options immédiates"), mais doivent toujours expliciter les décisions attendues.
+
 Chaque réponse de l'agent doit :
 - traiter explicitement toutes les questions posées dans `player_input.md` ;
 - actualiser les données pertinentes (état du monde, journaux, fiches) ;
-- préparer un nouveau `player_input.md` focalisé sur la scène suivante.
+- préparer un nouveau `player_input.md` focalisé sur la scène suivante avec des instructions claires de réponse.
 
 ## 9. Contenu additionnel
 - **PNJ majeurs** : liste initiale (généraux, diplomates, espions, mentors) avec arcs personnels.

--- a/logs/dice_rolls.log
+++ b/logs/dice_rolls.log
@@ -1,2 +1,4 @@
 # Journal des jets de dés — initialisé le 2025-09-26T21:10:12Z
 2025-09-27T08:30:00Z | Influence | Avantage (lien avec Maelis Veyr) | 18
+2025-09-29T10:12:00Z | Deplacement | Traque de Kaelith dans la brume | 17
+2025-09-29T10:13:30Z | Crochetage | Avantage (poussière de brume) | 16

--- a/player_input.md
+++ b/player_input.md
@@ -1,30 +1,37 @@
-# Journal du joueur
+# Interface joueur — Session 2025-09-26-A
 
-## Résumé de la dernière session
-- La mission de Lyra Valen débute : le Conseil des Huit Blasons lui confie la purification de la citerne de brume et la préparation d'une délégation vers Thorgar.
-- Les Lames de Cobalte contestent cette décision et tentent d'imposer un chevalier escortant.
-- Un espion de Serelune, Kaelith, a été repéré autour de la salle du Conseil et pourrait compromettre la trêve naissante.
+## Situation actuelle
+- Lyra a filé Kaelith jusqu'aux catacombes des artificiers et confirmé l'implication secrète de la maison Dyrion.
+- Elle détient un tube cristallin contenant un message chiffré intitulé « Glas de la Trêve » ainsi qu'une carte partielle des conduits alimentant la citerne de brume.
+- Les Lames de Cobalte ignorent encore sa disparition, mais des manifestations d'Ombre épaississent la brume dans le quartier.
 
-## Intentions pour la prochaine session
-- _Objectifs proposés :_
-  - Convaincre ou contourner l'escorte imposée pour conserver une marge de manœuvre diplomatique.
-  - Neutraliser Kaelith ou exploiter ses informations pour négocier avec Serelune.
-  - Stabiliser la citerne de brume afin de réduire l'influence de l'Ombre à Valoria.
-- _Alliés sollicités :_
-  - Chancelière Maelis Veyr pour un appui politique.
-  - Un messager runique de Thorgar si un sauf-conduit est obtenu.
-- _Ressources engagées :_
-  - Sceau d'émissaire valorien.
-  - Sachet de poussière de brume (peut offrir un avantage sur les tests de Crochetage/Discrétion).
+## Informations clés
+- **Dame Ilyana Corven** (chevalier imposé par les Lames) reste loyale à Valoria mais doit des faveurs à la maison Dyrion.
+- **Risques de la citerne** : en cas d'échec de purification, une onde de froid frappera le quartier des artisans avant d'exposer le palais à l'Ombre.
+- **Support potentiel** : la chancelière Maelis peut fournir un appui politique ou une équipe de cryptographes si elle est informée.
 
-## Questions à l'agent
-- Clarifications souhaitées :
-  - Quel est le nom et la loyauté du chevalier que les Lames de Cobalte veulent imposer ?
-  - Quels risques la purification de la citerne fait-elle peser sur les quartiers voisins en cas d'échec ?
-- Demandes spécifiques :
-  - Préparer un éventuel jet de Connaissances pour déchiffrer les messages chiffrés récupérés.
+## Options immédiates
+1. **Poursuivre Kaelith maintenant**
+   - Domaine pressenti : Déplacement / Combat.
+   - Objectif : capturer l'espion avant qu'il n'alerte Serelune.
+   - Risque : se retrouver isolée face à la manifestation d'Ombre.
+2. **Analyser le message « Glas de la Trêve »**
+   - Domaine pressenti : Connaissances (avantage si vous mentionnez l'usage des glyphes récupérés ou l'aide de Maelis).
+   - Objectif : découvrir le plan complet de sabotage et identifier les complices.
+   - Risque : temps nécessaire permettant à Kaelith de disparaître.
+3. **Infiltrer les conduits de la citerne immédiatement**
+   - Domaine pressenti : Crochetage / Magie.
+   - Objectif : neutraliser la source de corruption avant que la trêve ne soit compromise.
+   - Risque : tomber dans un piège runique sans soutien.
 
-## Choix du joueur attendus
-- Indiquer si Lyra accepte, négocie ou refuse la présence du chevalier escortant.
-- Préciser l'ordre des priorités entre diplomatie, traque de l'espion et purification de la citerne.
-- Décrire toute ressource supplémentaire que Lyra souhaite mobiliser avant de quitter Valoria.
+## Autres possibilités
+- Solliciter Dame Ilyana Corven pour tester sa loyauté ou la retourner contre la maison Dyrion.
+- Rejoindre Maelis pour préparer une riposte politique et coordonner une opération plus large.
+
+## Questions pour vous
+- Quelle option principale choisissez-vous parmi celles ci-dessus ?
+- Souhaitez-vous mobiliser des alliés (Maelis, Ilyana, autres) ou des ressources spécifiques ?
+- Y a-t-il une question supplémentaire à laquelle l'agent doit répondre avant l'action ?
+
+## Comment répondre
+Indiquez votre décision en répondant point par point (option choisie, ressources/alliés, questions supplémentaires). Votre réponse deviendra le prompt de l'itération suivante.


### PR DESCRIPTION
## Résumé
- Formalise le nouveau mode d'itération en documentant `player_input.md` comme terminal d'interaction et en mettant à jour la documentation associée.
- Poursuit la scène des ruelles en consignant les jets réussis de Lyra contre Kaelith et les indices récupérés dans les journaux et l'état du monde.
- Met à jour `player_input.md` pour proposer les options suivantes au joueur : poursuite de Kaelith, analyse du message ou infiltration de la citerne.

## Tests
- Aucun test automatisé n'a été exécuté pour cette itération.


------
https://chatgpt.com/codex/tasks/task_e_68d7128190cc8330ad6d1e9bae163b42