### PR TITLE
Clarifier la logique de partie et documenter les jets de dés

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,30 @@
 # Instructions générales du dépôt
 
+## Principes fondamentaux
 - Ce dépôt suit la **méthode de vibe coding de Mozi**. Avant toute modification, relire `docs/methode_vibe_coding_mozi.md`, l'étoile polaire et le backlog pour rester aligné.
 - Documenter chaque contribution dans `docs/backlog.md` en respectant l'ordre chronologique (dernière entrée en bas).
 - Les commits doivent refléter des itérations courtes et cohérentes.
 - Utiliser le français pour les documents et commentaires.
 - Les nouvelles ressources doivent préserver la vision stratégique du set/campagne décrite dans l'étoile polaire.
+
+## Logique de conduite d'une partie
+1. Lire intégralement `player_input.md` pour assimiler l'état courant de la scène et les questions du joueur.
+2. Consulter l'historique pertinent (`docs/histoire_session_en_cours.md`, journaux, fiches) si nécessaire afin de garantir la cohérence narrative.
+3. Préparer la réponse au joueur :
+   - Résoudre les actions demandées en décrivant les conséquences de manière immersive.
+   - Proposer la suite de la scène en restant fidèle à l'étoile polaire et aux informations canoniques.
+   - Mettre à jour `player_input.md` avec un résumé clair de la nouvelle situation et les invites destinées au joueur.
+4. Actualiser l'état du monde et les journaux concernés avec toute information nouvelle (PNJ, indices, ressources, etc.).
+5. Vérifier avant validation que chaque action de jeu a été consignée et que les documents impactés sont synchronisés.
+
+## Jets de dés et aléatoire
+- Les résolutions aléatoires doivent refléter de vrais jets de dés (d4, d6, d8, d10, d12, d20, etc.).
+- Utiliser la console de l'agent pour générer les résultats :
+  ```bash
+  python - <<'PY'
+  import random
+  print(random.randint(1, 20))  # exemple de jet de d20
+  PY
+  ```
+- Adapter la borne supérieure au type de dé requis (ex. `random.randint(1, 6)` pour un d6) et annoncer dans la narration le résultat du jet ainsi que le dé utilisé.
+- Conserver une trace des jets effectués dans les journaux ou fiches concernés afin de garantir la transparence vis-à-vis du joueur.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,15 @@ Ce dépôt suit la méthode de vibe coding de Mozi pour piloter une campagne de 
 - `player_input.md` fait désormais office de terminal d'interaction : il est réécrit à chaque itération pour résumer la scène en cours et demander explicitement au joueur quelles actions entreprendre. La réponse du joueur devient le prompt de l'itération suivante.
 - Un journal narratif incrémental est consigné dans `docs/histoire_session_en_cours.md` afin que le joueur puisse relire l'évolution de la partie.
 
+## Jets de dés
+- Les résolutions aléatoires doivent reproduire l'utilisation de dés physiques (d4, d6, d8, d10, d12, d20, etc.).
+- Générer chaque jet via la console en exécutant :
+  ```bash
+  python - <<'PY'
+  import random
+  print(random.randint(1, N))  # remplacer N par la valeur maximale du dé
+  PY
+  ```
+- Annoncer dans la narration le dé utilisé et le résultat obtenu, puis archiver le jet dans les journaux adéquats.
+
 Consulter `docs/requirements.md` pour la description complète du projet et `docs/backlog.md` pour l'historique des contributions.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,3 +6,4 @@
 - 2025-09-27 | Résolution de la scène du Conseil : Lyra refuse l'escorte, identification de la piste Kaelith et mise à jour des données de session et d'état du monde.
 - 2025-09-28 | Ajout des directives de réponse aux questions du joueur, création du journal narratif de session et mise à jour du README.
 - 2025-09-29 | Formalisation du terminal d'interaction joueur, narration de la filature de Kaelith et mise à jour des états du monde et des jets correspondants.
+- 2025-09-30 | Clarification de la logique de conduite de partie dans `AGENTS.md` et ajout des directives de jets de dés basées sur la console dans la documentation.


### PR DESCRIPTION
## Résumé
- structurer les instructions générales dans `AGENTS.md` en détaillant le déroulement d'une itération de jeu
- documenter l'utilisation de la console pour réaliser de vrais jets de dés dans `AGENTS.md` et le `README`
- tracer la mise à jour dans `docs/backlog.md`

## Tests
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68d716b9e7508330bf7e946aebaa4ea7