### PR TITLE
Narration : purge de la citerne et options post-rituel

### DIFF
--- a/data/world_state.json
+++ b/data/world_state.json
@@ -35,6 +35,18 @@
         "Lyra obtient une carte partielle des conduits de la citerne, ouvrant une piste d'infiltration.",
         "La cellule serelunienne active des mesures d'urgence pour sécuriser Kaelith."
       ]
+    },
+    {
+      "date": "2025-09-30",
+      "arc": "Arc I – Braises d'Empire",
+      "saison": "Automne 1235 FA",
+      "session": "2025-09-26-A",
+      "evenement": "Lyra avertit Maelis du complot de la maison Dyrion et purifie la citerne principale, contrecarrant l'opération Glas de la Trêve.",
+      "impact": [
+        "Maelis mobilise un réseau loyal pour couvrir les actions clandestines de Lyra.",
+        "La citerne valorienne est débarrassée du condensat d'Ombre, révélant un filament résiduel menant vers les agents sereluniens.",
+        "Les Lames de Cobalte renforcent les patrouilles dans les galeries de maintenance, augmentant la pression sur les infiltrés."
+      ]
     }
   ],
   "factions": {
@@ -59,7 +71,8 @@
         "Infiltration des Veilleurs du Voile",
         "Usure des Lames de Cobalte",
         "Complot anti-trêve au sein du Conseil",
-        "Complicité potentielle de la maison Dyrion"
+        "Complicité avérée de la maison Dyrion dans Glas de la Trêve",
+        "Patrouilles des Lames de Cobalte en alerte dans les galeries"
       ]
     },
     "Thorgar": {
@@ -104,7 +117,8 @@
       "menaces": [
         "Instabilité des marées magiques",
         "Division entre le clergé et les corsaires",
-        "Couverture de Kaelith compromise à Valoria"
+        "Couverture de Kaelith compromise à Valoria",
+        "Filament d'Ombre traçable vers le coordinateur"
       ]
     },
     "Khar'Seth": {
@@ -133,41 +147,71 @@
   "regions": {
     "Capitale valorienne": {
       "controle": "Valoria",
-      "conditions": ["Brumes instables", "Veille militaire renforcée"],
-      "anomalies": ["Résidus d'Ombre sous la citerne principale"],
-      "menaces": ["Veilleurs du Voile", "Espions de Serelune"]
+      "conditions": [
+        "Brumes instables",
+        "Veille militaire renforcée"
+      ],
+      "anomalies": [
+        "Résidus d'Ombre sous la citerne principale"
+      ],
+      "menaces": [
+        "Veilleurs du Voile",
+        "Espions de Serelune"
+      ]
     },
     "Montagnes de Thorgar": {
       "controle": "Thorgar",
-      "conditions": ["Premières neiges", "Routes commerciales fermées"],
+      "conditions": [
+        "Premières neiges",
+        "Routes commerciales fermées"
+      ],
       "anomalies": [],
-      "menaces": ["Famine", "Agitateurs du clan Marok"]
+      "menaces": [
+        "Famine",
+        "Agitateurs du clan Marok"
+      ]
     },
     "Archipel de Serelune": {
       "controle": "Serelune",
-      "conditions": ["Marées imprévisibles", "Voiles d'illusion"],
-      "anomalies": ["Tempêtes d'ombre sporadiques"],
-      "menaces": ["Corsaires dissidents", "Rituels incontrôlés"]
+      "conditions": [
+        "Marées imprévisibles",
+        "Voiles d'illusion"
+      ],
+      "anomalies": [
+        "Tempêtes d'ombre sporadiques"
+      ],
+      "menaces": [
+        "Corsaires dissidents",
+        "Rituels incontrôlés"
+      ]
     },
     "Désert de Khar'Seth": {
       "controle": "Khar'Seth",
-      "conditions": ["Vents brûlants", "Processions sacrées"],
-      "anomalies": ["Mirages arcanes"],
-      "menaces": ["Rébellion des porteurs de cristal", "Cultes de l'Ombre dans les dunes"]
+      "conditions": [
+        "Vents brûlants",
+        "Processions sacrées"
+      ],
+      "anomalies": [
+        "Mirages arcanes"
+      ],
+      "menaces": [
+        "Rébellion des porteurs de cristal",
+        "Cultes de l'Ombre dans les dunes"
+      ]
     }
   },
   "global_effects": [
     {
       "nom": "Ombre d'Ashkar",
       "niveau": 2,
-      "tendance": "stable",
-      "description": "L'influence de l'Ombre se manifeste par des résidus dans la brume valorienne et des visions partagées parmi les oracles."
+      "tendance": "recul léger",
+      "description": "La purge de la citerne apaise l'influence immédiate de l'Ombre, mais des filaments résiduels subsistent dans les réseaux clandestins."
     },
     {
       "nom": "Trêve fragile",
       "niveau": 1,
-      "tendance": "dégringolade",
-      "description": "L'accord entre Valoria et Thorgar dépend désormais de la capacité de Lyra à déjouer l'opération Glas de la Trêve tout en sécurisant le sauf-conduit."
+      "tendance": "stabilisation",
+      "description": "La neutralisation du condensat d'Ombre sécurise temporairement l'accord Valoria/Thorgar, bien que la maison Dyrion reste à neutraliser."
     }
   ]
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,3 +7,4 @@
 - 2025-09-28 | Ajout des directives de réponse aux questions du joueur, création du journal narratif de session et mise à jour du README.
 - 2025-09-29 | Formalisation du terminal d'interaction joueur, narration de la filature de Kaelith et mise à jour des états du monde et des jets correspondants.
 - 2025-09-30 | Clarification de la logique de conduite de partie dans `AGENTS.md` et ajout des directives de jets de dés basées sur la console dans la documentation.
+- 2025-09-30 | Rapport de la purge de la citerne par Lyra, coordination avec Maelis et mise à jour des options joueurs et de l'état du monde.

--- a/docs/histoire_session_en_cours.md
+++ b/docs/histoire_session_en_cours.md
@@ -22,3 +22,20 @@ Ce journal recueille l'évolution détaillée de la partie actuelle. Chaque inte
 - Sur la loyauté du chevalier proposé : il s'agit de Dame Ilyana Corven, loyaliste aux Lames de Cobalte mais redevable envers la maison Dyrion ; sa loyauté principale reste tournée vers la protection de Valoria.
 - Risques en cas d'échec de la purification : la pression de brume provoquerait une onde de froid qui toucherait d'abord les quartiers artisans, puis provoquerait des fissures qui exposeraient le palais à l'Ombre.
 - Préparation du jet de Connaissances : les glyphes récupérés offriront un avantage si Lyra prend le temps de les analyser ou de les confier à Maelis pour traduction.
+
+## 2025-09-30T12:20:00Z
+
+### Résumé narratif
+- Lyra tente de regagner la chancellerie par les galeries de maintenance, mais un voileur des Lames perçoit la vibration de brume qu'elle laisse dans son sillage ; elle doit brûler du temps pour effacer sa trace avant d'atteindre Maelis.
+- Une fois dans le cabinet scellé de la chancelière, elle expose le rôle de la maison Dyrion et livre le tube cristallin : Maelis dépêche ses cryptographes et active un protocole d'urgence pour isoler les quartiers loyaux.
+- L'analyse fulgurante du code « Glas de la Trêve » révèle que la citerne devait être noyée par un condensat d'Ombre ; Lyra, munie d'un cercle de purge improvisé par Maelis, s'infiltre dans les conduits et affronte la nappe corrompue.
+- Elle trace les glyphes inversés et déclenche la purge : la citerne vomit un geyser d'aigue-blafarde avant de revenir à un flux stable, mais l'onde de choc alerte les agents de Dyrion qui verrouillent désormais les accès secondaires.
+
+### Conséquences mécaniques
+- Jet de Déplacement (d20, difficulté 13) échoué avec un résultat de 9 : suspicion accrue des Lames de Cobalte, déclenchant des patrouilles renforcées dans les galeries.
+- Jet de Connaissances (d20 avec avantage grâce aux glyphes et aux cryptographes, difficulté 15) réussite critique avec un résultat de 20 : le protocole de sabotage est décodé et ses relais révélés.
+- Jet de Magie (d20, difficulté 13) réussi avec un résultat de 13 : la citerne principale est purifiée mais laisse un contrecoup d'énergie détectable.
+
+### Questions du joueur et réponses
+- Soutien de Maelis : elle met à disposition un relais de messagers et des agents loyaux capables d'occuper les Lames pendant que Lyra agit.
+- Conséquences immédiates : la maison Dyrion resserre la sécurité et tente de comprendre pourquoi la citerne est revenue à la normale, offrant une fenêtre étroite avant leur riposte.

--- a/logs/dice_rolls.log
+++ b/logs/dice_rolls.log
@@ -2,3 +2,6 @@
 2025-09-27T08:30:00Z | Influence | Avantage (lien avec Maelis Veyr) | 18
 2025-09-29T10:12:00Z | Deplacement | Traque de Kaelith dans la brume | 17
 2025-09-29T10:13:30Z | Crochetage | Avantage (poussière de brume) | 16
+2025-09-30T12:05:00Z | Deplacement | Retour discret vers la chancellerie | 9
+2025-09-30T12:07:00Z | Connaissances | Avantage (glyphes + cryptographes de Maelis) | 20
+2025-09-30T12:08:30Z | Magie | Rituel de purge de la citerne | 13

--- a/player_input.md
+++ b/player_input.md
@@ -1,37 +1,45 @@
 # Interface joueur — Session 2025-09-26-A
 
 ## Situation actuelle
-- Lyra a filé Kaelith jusqu'aux catacombes des artificiers et confirmé l'implication secrète de la maison Dyrion.
-- Elle détient un tube cristallin contenant un message chiffré intitulé « Glas de la Trêve » ainsi qu'une carte partielle des conduits alimentant la citerne de brume.
-- Les Lames de Cobalte ignorent encore sa disparition, mais des manifestations d'Ombre épaississent la brume dans le quartier.
+- Lyra a purgé la citerne principale grâce au rituel improvisé par Maelis, dissipant la nappe d'Ombre qui alimentait le complot « Glas de la Trêve ».
+- Son retour précipité a toutefois éveillé les soupçons : des patrouilles des Lames de Cobalte fouillent désormais les galeries de maintenance.
+- La maison Dyrion a resserré la sécurité de ses relais secrets, mais ignore encore que Lyra a décodé l'ensemble du protocole de sabotage.
+- Maelis a mobilisé un cercle restreint de fidèles prêts à fournir messagers, distractions et couverture politique pour les prochaines actions.
 
 ## Informations clés
-- **Dame Ilyana Corven** (chevalier imposé par les Lames) reste loyale à Valoria mais doit des faveurs à la maison Dyrion.
-- **Risques de la citerne** : en cas d'échec de purification, une onde de froid frappera le quartier des artisans avant d'exposer le palais à l'Ombre.
-- **Support potentiel** : la chancelière Maelis peut fournir un appui politique ou une équipe de cryptographes si elle est informée.
+- **Relais de la maison Dyrion** : trois caches identifiées alimentent la citerne en condensat d'Ombre ; deux restent actives et sont surveillées par des agents masqués.
+- **Patrouilles des Lames de Cobalte** : en alerte moyenne ; si elles trouvent des traces du rituel, elles exigeront une audience immédiate auprès du Conseil.
+- **Réserve d'énergie résiduelle** : le contrecoup de la purge laisse un filament d'Ombre pouvant être suivi jusqu'au coordinateur serelunien.
+- **Ressources de Maelis** : cryptographes disponibles, relais de messagers discrets, possibilité d'émettre des mandats scellés contre Dyrion (au risque de dévoiler la source).
 
 ## Options immédiates
-1. **Poursuivre Kaelith maintenant**
+1. **Exploiter la piste du filament d'Ombre**
+   - Domaine pressenti : Perception / Magie.
+   - Objectif : remonter la signature résiduelle jusqu'au coordinateur serelunien avant qu'elle ne se dissipe.
+   - Risque : croiser les patrouilles des Lames ou tomber sur un piège runique.
+2. **Frappes coordonnées sur les caches Dyrion restantes**
    - Domaine pressenti : Déplacement / Combat.
-   - Objectif : capturer l'espion avant qu'il n'alerte Serelune.
-   - Risque : se retrouver isolée face à la manifestation d'Ombre.
-2. **Analyser le message « Glas de la Trêve »**
-   - Domaine pressenti : Connaissances (avantage si vous mentionnez l'usage des glyphes récupérés ou l'aide de Maelis).
-   - Objectif : découvrir le plan complet de sabotage et identifier les complices.
-   - Risque : temps nécessaire permettant à Kaelith de disparaître.
-3. **Infiltrer les conduits de la citerne immédiatement**
-   - Domaine pressenti : Crochetage / Magie.
-   - Objectif : neutraliser la source de corruption avant que la trêve ne soit compromise.
-   - Risque : tomber dans un piège runique sans soutien.
+   - Objectif : neutraliser les relais encore actifs et capturer leurs agents.
+   - Risque : affrontement direct avec des gardes d'élite et perte de la couverture politique si l'opération échoue.
+3. **Manœuvre politique avec Maelis**
+   - Domaine pressenti : Influence.
+   - Objectif : utiliser les mandats scellés pour isoler la maison Dyrion, forcer les Lames de Cobalte à coopérer et sécuriser la trêve.
+   - Risque : révéler prématurément les preuves, permettant à Serelune d'adapter son complot.
+4. **Effacer les traces du rituel dans les galeries**
+   - Domaine pressenti : Crochetage / Discrétion.
+   - Objectif : réduire la surveillance des Lames en supprimant tout indice de la purge.
+   - Risque : temps investi laissant le coordinateur serelunien se retrancher.
 
 ## Autres possibilités
-- Solliciter Dame Ilyana Corven pour tester sa loyauté ou la retourner contre la maison Dyrion.
-- Rejoindre Maelis pour préparer une riposte politique et coordonner une opération plus large.
+- Confier à Dame Ilyana une mission d'écran pour détourner les Lames et mesurer sa loyauté.
+- Rétablir un contact discret avec Kaelith pour tenter de retourner l'espion avec les informations décodées.
+- Préparer une diversion arcanique via les cryptographes pour saturer les capteurs de brume.
 
 ## Questions pour vous
 - Quelle option principale choisissez-vous parmi celles ci-dessus ?
-- Souhaitez-vous mobiliser des alliés (Maelis, Ilyana, autres) ou des ressources spécifiques ?
+- Souhaitez-vous employer les ressources de Maelis (mandats, messagers, cryptographes) et comment ?
+- Quelles précautions prenez-vous vis-à-vis des Lames de Cobalte pendant l'opération ?
 - Y a-t-il une question supplémentaire à laquelle l'agent doit répondre avant l'action ?
 
 ## Comment répondre
-Indiquez votre décision en répondant point par point (option choisie, ressources/alliés, questions supplémentaires). Votre réponse deviendra le prompt de l'itération suivante.
+Indiquez votre décision en répondant point par point (option choisie, ressources/alliés, précautions, questions supplémentaires). Votre réponse deviendra le prompt de l'itération suivante.


### PR DESCRIPTION
## Résumé
- Raconte le retour de Lyra auprès de Maelis, la purge de la citerne et consigne les jets associés dans le journal de session.
- Actualise l'interface joueur et le backlog avec les nouvelles options tactiques et l'état du monde.
- Met à jour `world_state.json` et le journal des jets pour refléter l'impact de l'opération Glas de la Trêve.

## Tests
- Aucun (documentation narrative)


------
https://chatgpt.com/codex/tasks/task_e_68d717b102748330afb6a2b298338111