### PR TITLE
Documenter la dispersion du filament d'Ombre vers les serres sereluniennes

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,3 +8,4 @@
 - 2025-09-29 | Formalisation du terminal d'interaction joueur, narration de la filature de Kaelith et mise à jour des états du monde et des jets correspondants.
 - 2025-09-30 | Clarification de la logique de conduite de partie dans `AGENTS.md` et ajout des directives de jets de dés basées sur la console dans la documentation.
 - 2025-09-30 | Rapport de la purge de la citerne par Lyra, coordination avec Maelis et mise à jour des options joueurs et de l'état du monde.
+- 2025-09-30 | Rapport sur la dispersion du filament d'Ombre, coordination des mandats de Maelis et mise à jour des options joueur incluant la surveillance des serres sereluniennes.

--- a/docs/histoire_session_en_cours.md
+++ b/docs/histoire_session_en_cours.md
@@ -39,3 +39,19 @@ Ce journal recueille l'évolution détaillée de la partie actuelle. Chaque inte
 ### Questions du joueur et réponses
 - Soutien de Maelis : elle met à disposition un relais de messagers et des agents loyaux capables d'occuper les Lames pendant que Lyra agit.
 - Conséquences immédiates : la maison Dyrion resserre la sécurité et tente de comprendre pourquoi la citerne est revenue à la normale, offrant une fenêtre étroite avant leur riposte.
+
+## 2025-09-30T14:50:00Z
+
+### Résumé narratif
+- Sur l'insistance de Lyra, Maelis scelle trois mandats d'urgence qui gelent les discussions du Conseil et dépêchent ses messagers pour rassurer les factions pacifistes, verrouillant provisoirement la trêve autour de la chancellerie.
+- Lyra plonge à nouveau dans la citerne purifiée et suit le filament d'Ombre, mais la traînée se disperse dans un maillage de runes leurres : elle ne récolte qu'une direction fragmentaire pointant vers les serres sereluniennes situées sous la verrière nord.
+- Profitant d'un repli dans les conduits, elle tresse un appel de brume vers Kaelith ; l'espion répond par un écho étouffé qui évoque une "lumière tronquée" avant que la connexion ne soit étouffée par une interférence métallique.
+
+### Conséquences mécaniques
+- Jet de Magie (d20, difficulté 15) échoué avec un résultat de 2 : le filament est brouillé ; Lyra gagne uniquement une direction approximative et laisse derrière elle une pulsation perceptible par les veilleurs d'Ombre.
+- Jet d'Influence (d20, difficulté 12) partiellement réussi avec un résultat de 10 : le message atteint Kaelith mais la réponse est fragmentée, suggérant qu'il est sous surveillance ou qu'un amortisseur runique filtre leurs échanges.
+- Les mandats de Maelis accroissent la protection politique (+1 avantage circonstanciel aux prochaines négociations) mais attisent la méfiance de la maison Dyrion qui dépêche des auditeurs vers les serres.
+
+### Questions du joueur et réponses
+- Interprétation de la "lumière tronquée" : Kaelith emploie ce code lorsqu'une voie est surveillée par un miroir d'anti-brume ; il indique que la route vers le coordinateur est piégée par un dispositif de réflexion.
+- Délai avant dissipation complète du filament : sans rituel supplémentaire, la signature se dissipera d'ici deux rotations de sablier (≈1 heure), forçant Lyra à agir rapidement ou à renforcer la piste.

--- a/logs/dice_rolls.log
+++ b/logs/dice_rolls.log
@@ -5,3 +5,5 @@
 2025-09-30T12:05:00Z | Deplacement | Retour discret vers la chancellerie | 9
 2025-09-30T12:07:00Z | Connaissances | Avantage (glyphes + cryptographes de Maelis) | 20
 2025-09-30T12:08:30Z | Magie | Rituel de purge de la citerne | 13
+2025-09-30T14:45:00Z | Magie | Suivre le filament d'Ombre depuis la citerne | 2
+2025-09-30T14:47:00Z | Influence | Établir un contact voilé avec Kaelith via la brume | 10

--- a/player_input.md
+++ b/player_input.md
@@ -1,44 +1,44 @@
 # Interface joueur — Session 2025-09-26-A
 
 ## Situation actuelle
-- Lyra a purgé la citerne principale grâce au rituel improvisé par Maelis, dissipant la nappe d'Ombre qui alimentait le complot « Glas de la Trêve ».
-- Son retour précipité a toutefois éveillé les soupçons : des patrouilles des Lames de Cobalte fouillent désormais les galeries de maintenance.
-- La maison Dyrion a resserré la sécurité de ses relais secrets, mais ignore encore que Lyra a décodé l'ensemble du protocole de sabotage.
-- Maelis a mobilisé un cercle restreint de fidèles prêts à fournir messagers, distractions et couverture politique pour les prochaines actions.
+- Maelis a scellé trois mandats d'urgence pour suspendre les conciliabules du Conseil et réaffirmer la trêve, tout en déployant ses messagers pour contenir les rumeurs.
+- Lyra a replongé dans la citerne : le filament d'Ombre s'est diffusé dans un réseau de runes leurres, ne laissant qu'une direction approximative vers les serres sereluniennes sous la verrière nord.
+- La tentative de contact avec Kaelith a abouti à un écho fragmenté mentionnant une « lumière tronquée », signe d'une surveillance par miroirs d'anti-brume.
+- Les mandats ont attiré l'attention de la maison Dyrion : des auditeurs se dirigent vers les serres, épaulés par des veilleurs d'Ombre sensibles aux pulsations laissées par la traque de Lyra.
 
 ## Informations clés
-- **Relais de la maison Dyrion** : trois caches identifiées alimentent la citerne en condensat d'Ombre ; deux restent actives et sont surveillées par des agents masqués.
-- **Patrouilles des Lames de Cobalte** : en alerte moyenne ; si elles trouvent des traces du rituel, elles exigeront une audience immédiate auprès du Conseil.
-- **Réserve d'énergie résiduelle** : le contrecoup de la purge laisse un filament d'Ombre pouvant être suivi jusqu'au coordinateur serelunien.
-- **Ressources de Maelis** : cryptographes disponibles, relais de messagers discrets, possibilité d'émettre des mandats scellés contre Dyrion (au risque de dévoiler la source).
+- **Serres sereluniennes** : réseau de couloirs vitrés sous la verrière nord, truffé de capteurs de lumière et de miroirs d'anti-brume ; l'accès principal est tenu par deux agents masqués de Dyrion.
+- **Filament résiduel** : se dissipera dans ~1 heure sans rituel de stabilisation ; il pulse à intervalles irréguliers, détectables par les veilleurs d'Ombre.
+- **Miroirs d'anti-brume** : dispositifs qui renvoient ou dispersent la magie de brume ; le code « lumière tronquée » indique qu'ils surveillent la voie directe vers le coordinateur.
+- **Mandats de Maelis** : offrent une couverture politique temporaire (avantage lors d'interactions diplomatiques), mais tout excès de violence sera désormais scruté par les auditeurs de Dyrion.
 
 ## Options immédiates
-1. **Exploiter la piste du filament d'Ombre**
-   - Domaine pressenti : Perception / Magie.
-   - Objectif : remonter la signature résiduelle jusqu'au coordinateur serelunien avant qu'elle ne se dissipe.
-   - Risque : croiser les patrouilles des Lames ou tomber sur un piège runique.
-2. **Frappes coordonnées sur les caches Dyrion restantes**
-   - Domaine pressenti : Déplacement / Combat.
-   - Objectif : neutraliser les relais encore actifs et capturer leurs agents.
-   - Risque : affrontement direct avec des gardes d'élite et perte de la couverture politique si l'opération échoue.
-3. **Manœuvre politique avec Maelis**
-   - Domaine pressenti : Influence.
-   - Objectif : utiliser les mandats scellés pour isoler la maison Dyrion, forcer les Lames de Cobalte à coopérer et sécuriser la trêve.
-   - Risque : révéler prématurément les preuves, permettant à Serelune d'adapter son complot.
-4. **Effacer les traces du rituel dans les galeries**
-   - Domaine pressenti : Crochetage / Discrétion.
-   - Objectif : réduire la surveillance des Lames en supprimant tout indice de la purge.
-   - Risque : temps investi laissant le coordinateur serelunien se retrancher.
+1. **Forcer la piste vers les serres**
+   - Domaine pressenti : Discrétion / Magie.
+   - Objectif : traverser les miroirs d'anti-brume, atteindre le coordinateur serelunien et exploiter la direction obtenue.
+   - Risque : déclencher les alarmes lumineuses et être pris entre les agents Dyrion et les veilleurs d'Ombre.
+2. **Stabiliser le filament avant qu'il ne s'éteigne**
+   - Domaine pressenti : Magie / Connaissances.
+   - Objectif : ériger un nœud de brume pour fixer la signature et gagner du temps.
+   - Risque : nouvelle pulsation détectable par les patrouilles ; possible contrecoup si le nœud s'effondre.
+3. **Piéger les auditeurs de Dyrion en détournant les mandats**
+   - Domaine pressenti : Influence / Stratégie.
+   - Objectif : utiliser la couverture politique pour faire escorter les auditeurs par des loyalistes et contrôler leur progression.
+   - Risque : révéler la manipulation si les loyalistes échouent, compromettant l'alliance avec Maelis.
+4. **Rechercher un accès secondaire aux serres**
+   - Domaine pressenti : Crochetage / Exploration.
+   - Objectif : exploiter les conduits d'arrosage ou les gaines de lumière pour contourner les miroirs.
+   - Risque : temps consommé, au risque que le filament disparaisse avant l'infiltration.
 
 ## Autres possibilités
-- Confier à Dame Ilyana une mission d'écran pour détourner les Lames et mesurer sa loyauté.
-- Rétablir un contact discret avec Kaelith pour tenter de retourner l'espion avec les informations décodées.
-- Préparer une diversion arcanique via les cryptographes pour saturer les capteurs de brume.
+- Confier aux cryptographes de Maelis la stabilisation du filament pendant que Lyra se prépare pour l'infiltration.
+- Mettre Dame Ilyana sur la piste des veilleurs d'Ombre pour détourner leur attention des pulsations.
+- Tenter de localiser l'interférence métallique qui a coupé Kaelith afin de savoir qui surveille ses communications.
 
 ## Questions pour vous
 - Quelle option principale choisissez-vous parmi celles ci-dessus ?
-- Souhaitez-vous employer les ressources de Maelis (mandats, messagers, cryptographes) et comment ?
-- Quelles précautions prenez-vous vis-à-vis des Lames de Cobalte pendant l'opération ?
+- Souhaitez-vous employer les ressources de Maelis (mandats, messagers, cryptographes, alliés) et comment ?
+- Quelles précautions prenez-vous vis-à-vis des agents de Dyrion et des veilleurs d'Ombre pendant l'opération ?
 - Y a-t-il une question supplémentaire à laquelle l'agent doit répondre avant l'action ?
 
 ## Comment répondre


### PR DESCRIPTION
## Résumé
- Ajout d'une nouvelle section narrative sur la poursuite du filament d'Ombre et la réponse de Maelis.
- Actualisation de l'interface joueur avec la situation dans les serres et les options associées.
- Journalisation des jets de Magie et d'Influence correspondants et mise à jour du backlog.

## Tests
- Aucun test automatisé requis.


------
https://chatgpt.com/codex/tasks/task_e_68d71b0951888330991813a81ae441c5